### PR TITLE
Add user to generated docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,6 @@ RUN mkdir -p /ipfs && \
     cd go-ipfs && \
     ./install.sh
 
-# install WASM toolchain
-RUN /root/.cargo/bin/rustup target install wasm32-unknown-unknown
-
 # install packages needed for substrate
 RUN apt-get update && \
     apt-get install -y cmake pkg-config libssl-dev git gcc build-essential clang libclang-dev && \
@@ -70,11 +67,23 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/archives/*
 
+ARG USER_ID
+ARG GROUP_ID
+
+RUN addgroup --gid $GROUP_ID user
+RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
+USER user
+
+# install rust as the current user
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# install WASM toolchain
+RUN $HOME/.cargo/bin/rustup target install wasm32-unknown-unknown
+
 # set environment variables
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm
 ENV SGX_SDK /opt/sgxsdk
-ENV PATH "$PATH:${SGX_SDK}/bin:${SGX_SDK}/bin/x64:/root/.cargo/bin"
+ENV PATH "$PATH:${SGX_SDK}/bin:${SGX_SDK}/bin/x64:${HOME}/.cargo/bin"
 ENV PKG_CONFIG_PATH "${PKG_CONFIG_PATH}:${SGX_SDK}/pkgconfig"
 ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${SGX_SDK}/sdk_libs"
 ENV CC /usr/bin/clang-10

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,8 @@ RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID devadm
 RUN adduser devadmin sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER devadmin
+ENV HOME /home/devadmin
+WORKDIR $HOME
 
 # install rust as the current user
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,12 @@ RUN apt-get update && \
 ARG USER_ID
 ARG GROUP_ID
 
-RUN addgroup --gid $GROUP_ID user
-RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
-USER user
+RUN addgroup --gid $GROUP_ID devadmin
+RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID devadmin
+# make add user to sudoer
+RUN adduser devadmin sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+USER devadmin
 
 # install rust as the current user
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/README.md
+++ b/README.md
@@ -142,7 +142,15 @@ If you want to build the docker image yourself, use the following command:
 
 This script will define the desired versions of the components and build the Docker as described in the `Dockerfile`.
 
-Pre-built docker images are also available on [docker hub](https://hub.docker.com/repository/docker/scssubstratee/substratee_dev/tags).
+It also adds the current user to the docker. The docker will start by default with the `USER_ID` and `GROUP_ID` that executed the build afterwards. This takes care of permission issues on docker generated/modified files and it allows seamless editing on the host while building and running in the docker.
+
+The following command mounts the current directory into docker and publishes the default ports of the binaries to the host:
+
+```
+docker run -it --mount "type=bind,src=$(pwd),dst=/opt/shared" --workdir /opt/shared  -p 9979:9944 -p 2079:2000 -p 3079:3443 scssubstratee/substratee_dev:1804-2.12-1.1.3-001-user-1000-group-1000 /bin/bash
+```
+
+Pre-built docker images are also available on [docker hub](https://hub.docker.com/repository/docker/scssubstratee/substratee_dev/tags). **Note:** The pre-built images will always run as root. Any files generated withing docker can only be changed with root access.
 
 ## Demo
 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -20,6 +20,8 @@ export VERSION_RUST_SGX_SDK=1.1.3
 export VERSION_INTEL_SGX_SDK=2.12
 export VERSION_IPFS=0.4.21
 export VERSION_IMAGE=001
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
 
 set -ex
 
@@ -28,5 +30,7 @@ docker build --target development \
     --build-arg VERSION_UBUNTU=$VERSION_UBUNTU \
     --build-arg VERSION_RUST_SGX_SDK=$VERSION_RUST_SGX_SDK \
     --build-arg VERSION_IPFS=$VERSION_IPFS \
-    -t scssubstratee/substratee_dev:$VERSION_UBUNTU-$VERSION_INTEL_SGX_SDK-$VERSION_RUST_SGX_SDK-$VERSION_IMAGE \
+    --build-arg USER_ID=$USER_ID \
+    --build-arg GROUP_ID=$GROUP_ID \
+    -t scssubstratee/substratee_dev:$VERSION_UBUNTU-$VERSION_INTEL_SGX_SDK-$VERSION_RUST_SGX_SDK-$VERSION_IMAGE-user-$USER_ID-group-$GROUP_ID \
     -f ./Dockerfile .


### PR DESCRIPTION
The docker_build.sh script takes into account the current user executing the build and adds the user to the generated docker image. The docker is started by default with that user's USER_ID and GROUP_ID.

This fixes the permission issues for docker generated files on the host system.

**Note:  the build needs to be executed locally to work.** This will not work for the images on dockerhub